### PR TITLE
Unique ids bug fix

### DIFF
--- a/jupyter_book_to_htmlbook/xref_processing.py
+++ b/jupyter_book_to_htmlbook/xref_processing.py
@@ -62,4 +62,5 @@ def process_ids(chapter, existing_ids=[]):
             # log the change
             logging.info(f"Duplicate ID \"{uid}\" changed to \"{new_id}\"")
 
-    return chapter, chapter.find_all(id=True)
+    chapter_ids = [element['id'] for element in chapter.find_all(id=True)]
+    return chapter, chapter_ids

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jupyter-book-to-htmlbook"
-version = "1.0.1"
+version = "1.0.2"
 description = "A script to convert jupyter book html files to htmlbook for consumption in Atlas"
 authors = ["delfanbaum"]
 

--- a/tests/test_unique_ids.py
+++ b/tests/test_unique_ids.py
@@ -16,7 +16,7 @@ def test_unique_ids():
     chapter = BeautifulSoup("""<h1 id="foo">Hello</h1>""", "html.parser")
     result, chapter_ids = process_ids(chapter, existing_ids)
     assert re.search(r'id="foo_[0-9]+', str(result))
-    assert len(chapter_ids) == 1
+    assert re.match(r'foo_[0-9]+', chapter_ids[0])
 
 
 def test_xrefs_are_updated_when_ids_change():


### PR DESCRIPTION
I was returning a list of HTML elements instead of a list of IDs... and the test wasn't well written, so it passed because I was just checking length; this PR fixes this bug that was still allowing duplicate IDs to get through.