### PR TITLE
Quiet jb book builds

### DIFF
--- a/jupyter_book_to_htmlbook/main.py
+++ b/jupyter_book_to_htmlbook/main.py
@@ -85,8 +85,13 @@ def jupter_book_to_htmlbook(
         # Bonus is that it keeps the command similar to what an author will be
         # using locally.
         import subprocess
-        jb_info = subprocess.run(['jupyter-book', 'build',
-                                 source],
+        jb_info = subprocess.run(['jupyter-book',
+                                  'build',
+                                  source,
+                                  # silence warnings, which instead appear to
+                                  # error out inside Atlas; instead we'll rely
+                                  # on Atlas's own missing xref checker
+                                  '-qq'],
                                  # hide chatty jupyter-book build output
                                  stdout=subprocess.DEVNULL)
         # but log any errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jupyter-book-to-htmlbook"
-version = "1.0.3"
+version = "1.0.4"
 description = "A script to convert jupyter book html files to htmlbook for consumption in Atlas"
 authors = ["delfanbaum"]
 


### PR DESCRIPTION
Atlas is failing when we have partial book builds in the _toc.yml file because of the way the `jupyter-book build` script works. We're now going to really silence that script and handle the errors in our script//in Atlas.