### PR TITLE
Add skip numbering option

### DIFF
--- a/jupyter_book_to_htmlbook/code_processing.py
+++ b/jupyter_book_to_htmlbook/code_processing.py
@@ -3,7 +3,7 @@ import logging
 from bs4 import NavigableString  # type: ignore
 
 
-def process_code(chapter):
+def process_code(chapter, skip_numbering=False):
     """
     Turn rendered <pre> blocks into appropriately marked-up HTMLBook
     """
@@ -50,7 +50,8 @@ def process_code(chapter):
                 pre_tag["data-code-language"] = "python"
 
             # apply numbering
-            cell_number = number_codeblock(pre_tag, cell_number)
+            if not skip_numbering:
+                cell_number = number_codeblock(pre_tag, cell_number)
 
         except TypeError:
             logging.warning(f"Unable to apply cell numbering to {div}")

--- a/jupyter_book_to_htmlbook/file_processing.py
+++ b/jupyter_book_to_htmlbook/file_processing.py
@@ -230,7 +230,8 @@ def move_span_ids_to_sections(chapter):
 def process_chapter(toc_element,
                     source_dir,
                     build_dir=Path('.'),
-                    book_ids: list = []):
+                    book_ids: list = [],
+                    skip_cell_numbering: bool = False):
     """
     Takes a list of chapter files and chapter lists and then writes the chapter
     to the root directory in which the script is run. Note that this assumes
@@ -260,7 +261,7 @@ def process_chapter(toc_element,
     chapter = process_footnotes(chapter)
     chapter = process_admonitions(chapter)
     chapter = process_math(chapter)
-    chapter = process_code(chapter)
+    chapter = process_code(chapter, skip_cell_numbering)
     chapter = move_span_ids_to_sections(chapter)
     chapter = process_subsections(chapter)
     chapter, ids = process_ids(chapter, book_ids)

--- a/jupyter_book_to_htmlbook/main.py
+++ b/jupyter_book_to_htmlbook/main.py
@@ -34,6 +34,11 @@ def jupter_book_to_htmlbook(
             "--skip-jb-build",
             help="Skip running `jupyter-book` as a part of this conversion"
             ),
+        skip_cell_numbering: Optional[bool] = typer.Option(
+            False,
+            "--skip-numbering",
+            help="Skip the numbering of In[]/Out[] code cells"
+            ),
         include_root: Optional[bool] = typer.Option(
             False,
             "--include-root",
@@ -126,7 +131,8 @@ def jupter_book_to_htmlbook(
             file, chapter_ids = process_chapter(element,
                                                 source_dir,
                                                 output_dir,
-                                                book_ids)
+                                                book_ids,
+                                                skip_cell_numbering)
             processed_files.append(f'{target}/{file}')
             book_ids.extend(chapter_ids)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -46,6 +46,32 @@ class TestMain:
         with open(tmp_path / 'build/notebooks/ch01.html', 'rt') as f:
             assert 'data-type="chapter"' in f.read()
 
+    def test_skip_code(self,
+                       tmp_path,
+                       monkeypatch: pytest.MonkeyPatch,
+                       caplog):
+        """
+        Ensure that when we say to skip numbering, code cells aren't numbered
+        """
+        # setup
+        caplog.set_level(logging.DEBUG)
+        test_env = tmp_path / 'tmp'
+        test_env.mkdir()
+        shutil.copytree('tests/example_book', test_env, dirs_exist_ok=True)
+        monkeypatch.chdir(tmp_path)  # patch for our build target
+
+        # run, skipping build since it's included in example dir
+        result = runner.invoke(app, [str(test_env), 'build',
+                                     '--skip-jb-build',
+                                     '--skip-numbering'])
+        log = caplog.text
+        assert result.exit_code == 0
+        assert "jupyter-book run" in log
+        assert os.path.isfile(tmp_path / 'build/part-1.html')
+        with open(tmp_path / 'build/notebooks/ch01.html', 'rt') as f:
+            assert 'In [' not in f.read()
+            assert 'Out[' not in f.read()
+
     def test_simple_case_with_json(self,
                                    tmp_path,
                                    monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Quick PR: 
Authors may not want to include cell numbering in their books for whatever reason. This commit adds a flag for skipping the numbering (which is enabled by default) and a test to confirm it.