### PR TITLE
Update id moving scheme for headings/xrefs

### DIFF
--- a/jupyter_book_to_htmlbook/text_processing.py
+++ b/jupyter_book_to_htmlbook/text_processing.py
@@ -41,19 +41,20 @@ def clean_chapter(chapter, rm_numbering=True):
 
 def move_span_ids_to_sections(chapter):
     """
-    Takes span tags with "sec-" ids and moves the id to the parent section tag
-    so Atlas can find the cross reference.
+    Takes empty span tags under a section parent with a heading next sibling
+    and moves the id to the parent section tag so Atlas can find the cross
+    reference.
     """
-    sec_spans = chapter.find_all("span", id=re.compile('sec-*'))
-    for span in sec_spans:
-        # get id
-        span_id = span['id']
-        # get next heading
-        section = span.find_parent('section')
-        # add span id to section
-        section['id'] = span_id
-        # remove span so no dup ids
-        span.decompose()
+    empty_id_spans = chapter.find_all("span", id=True, string="")
+    for span in empty_id_spans:
+        if (
+                span.parent.name == "section" and
+                span.next_sibling.name in ["h1", "h2", "h3", "h4", "h5"]
+           ):
+            # add span id to section
+            span.parent['id'] = span['id']
+            # remove the now unneeded span
+            span.decompose()
     return chapter
 
 

--- a/tests/test_text_processing.py
+++ b/tests/test_text_processing.py
@@ -43,20 +43,21 @@ div class="cell_input docutils container"&gt;
 def test_move_span_ids_to_sections():
     """
     Atlas requires that cross reference targets sections so that
-    the text will appear as expected. This test is to confirm that
-    the ids we added ("sec-") to the invisible spans earlier for cross
-    referencing are then applied to the parent section.
+    the links and cross-reference text will appear as expected in Atlas
     """
     chapter_text = """
+<section data-type="chapter" id="analytics" xmlns="http://w3.org/1999/xhtml">
+<span id="chp-1"></span><h1>Analytics</h1>
 <section class="section" data-type="sect2" id="types-of-bias">
 <span id="sec-biastypes"></span><h2>Types of Bias</h2>
-<p>Bias comes in many forms!</p>"""
+<p>Bias <span id="donotmove"></span>comes in many forms!</p>
+</section></section>"""
     chapter = BeautifulSoup(chapter_text, 'html.parser')
     result = move_span_ids_to_sections(chapter)
-    assert str(result) == """
-<section class="section" data-type="sect2" id="sec-biastypes">
-<h2>Types of Bias</h2>
-<p>Bias comes in many forms!</p></section>"""
+    sections = result.find_all("section")
+    assert sections[0]["id"] == "chp-1"
+    assert sections[1]["id"] == "sec-biastypes"
+    assert not result.find("p", id=True)
 
 
 def test_sidebar_processing():


### PR DESCRIPTION
This commit fixes a hangover-bug from the original iteration of this script wherein we were manually applying IDs to top-level (chapter) section headings and doing the linking that way (this was a result of the less-good linking strategy of the earlier target version of Jupyter Book).

This commit updates it to what it should be, namely looks for an empty span right under a section and right next to a heading, and moves that ID to the section so Atlas can go on to find the cross reference. Minor test/code refactor but an important one!