### PR TITLE
Remove table attrs

### DIFF
--- a/jupyter_book_to_htmlbook/text_processing.py
+++ b/jupyter_book_to_htmlbook/text_processing.py
@@ -1,20 +1,22 @@
-import re
-
-
 def clean_chapter(chapter, rm_numbering=True):
     """
     "Cleans" the chapter from any script or style tags, removes table borders,
-    removes any style attrs, and by default removes any section numbering.
+    table valign/width attributes, removes any style attrs, and by default
+    removes any section numbering.
     """
     remove_tags = ['style', 'script']
+    remove_attrs = ['style', 'valign', 'halign', 'width']
+
     all_tags = chapter.find_all()
     for tag in all_tags:
         if tag.name in remove_tags:
             tag.decompose()
         if tag.name == 'table':
             del tag['border']
-    for tag in chapter.find_all(attrs={'style': True}):
-        del tag['style']
+
+    for attr in remove_attrs:
+        for tag in chapter.find_all(attrs={attr: True}):
+            del tag[attr]
 
     # (optionally) remove numbering
     if rm_numbering:

--- a/tests/test_file_processing.py
+++ b/tests/test_file_processing.py
@@ -52,7 +52,7 @@ class TestChapterProcess:
         # check on return
         assert "ch01.html" in result
 
-    def test_chapter_promote_headings(self, tmp_path, caplog):
+    def test_chapter_promote_headings(self, tmp_path):
         """
         we expect to have a single h1 and then a bunch of h2s
         in a single-file chapter, but we need to promote all the headings
@@ -227,9 +227,10 @@ id="this-is-another-subheading">
     <h1>Hello!</h1>
 </div>""")
         # first item is the intro file, so let's check on the first "chapter"
+        caplog.set_level(logging.DEBUG)
         with pytest.raises(RuntimeError):
             process_chapter(tmp_path / 'malformed.html', tmp_path)
-            assert "Failed to process" in caplog.text
+        assert "Failed to process" in caplog.text
 
     @pytest.mark.parametrize(
             "datatype", [

--- a/tests/test_text_processing.py
+++ b/tests/test_text_processing.py
@@ -40,6 +40,28 @@ div class="cell_input docutils container"&gt;
 </h2>"""
 
 
+def test_chapter_cleans_table_specific():
+    """
+    A few table-specific edge cases to check, including a no-border table
+    and tables with valign/width attributes
+    """
+    chapter = BeautifulSoup("""<table>
+<tr halign="left">
+<th rowspan="2" valign="top">0</th>
+<td width="50%">NaN</td>
+<td>NaN</td>
+<td>NaN</td>
+</tr>
+</table>""", "html.parser")
+    result = clean_chapter(chapter)
+    halign_tr = result.find("tr")
+    valign_th = result.find("th")
+    width_td = result.find("td")  # it'll find the first
+    assert not halign_tr.get("valign")
+    assert not valign_th.get("valign")
+    assert not width_td.get("width")
+
+
 def test_move_span_ids_to_sections():
     """
     Atlas requires that cross reference targets sections so that


### PR DESCRIPTION
Per TOOLSREQ-8317, we weren't actually filtering out things like `valign`, and it was causing epub errors. This PR adds that filtering, and fixes one extraneous test. 