### PR TITLE
Remove part titlecasing per PE feedback

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -25,6 +25,8 @@ jobs:
           virtualenvs-in-project: true
           installer-parallel: true
 
+      - run: poetry config installer.modern-installation false
+
       - name: Load cached venv if possible
         id: cached-poetry-dependencies
         uses: actions/cache@v2

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# These owners will be the default owners for everything in
+# the repo.
+*       @oreillymedia/tools-team

--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ Options:
 
 ## Release Notes
 
+### 1.0.8
+
+Bug fixes:
+- Part caption casing is preserved from `_toc.yaml`
+
 ### 1.0.7
 
 Features:

--- a/jupyter_book_to_htmlbook/file_processing.py
+++ b/jupyter_book_to_htmlbook/file_processing.py
@@ -32,7 +32,7 @@ def process_part(part_path: Path, output_dir: Path):
     if info:
         part_number = info.group(1)
         # undo earlier space replacement and do a simple title case
-        part_name = info.group(2).replace('-', ' ').title()
+        part_name = info.group(2).replace('-', ' ')
 
         with open(output_dir / f'part-{part_number}.html', 'wt') as f:
             f.write(f"""

--- a/jupyter_book_to_htmlbook/toc_processing.py
+++ b/jupyter_book_to_htmlbook/toc_processing.py
@@ -119,7 +119,7 @@ def process_parts(parts, src_dir):
         part_number += 1  # increment numbering
         # create a distinct placeholder Path for downstream processing
         try:
-            part_title = part["caption"].replace(' ', '-').lower()
+            part_title = part["caption"].replace(' ', '-')
         except TypeError:  # because it's looking for a string, getting an int
             message = ("Missing part caption in _toc.yml. " +
                        "Part captions are required.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jupyter-book-to-htmlbook"
-version = "1.0.7"
+version = "1.0.8"
 description = "A script to convert jupyter book html files to htmlbook for consumption in Atlas"
 authors = ["delfanbaum"]
 

--- a/tests/test_part_processing.py
+++ b/tests/test_part_processing.py
@@ -12,13 +12,13 @@ class TestPartProcessing:
         Take a path with the appropriate part designation, and create
         a file with the appropriate numbering and name
         """
-        part_path = Path(tmp_path / '_jb_part-1-name-of-part.html')
+        part_path = Path(tmp_path / '_jb_part-1-Name-of-Part.html')
         result = process_part(part_path, tmp_path)
         assert result == 'part-1.html'
         with open(tmp_path / 'part-1.html') as f:
             assert f.read() == """
 <div xmlns="http://www.w3.org/1999/xhtml" data-type="part" id="part-1">
-<h1>Name Of Part</h1>
+<h1>Name of Part</h1>
 </div>""".lstrip()
 
     def test_process_part_bad_name(self, tmp_path, caplog):

--- a/tests/test_toc_processing.py
+++ b/tests/test_toc_processing.py
@@ -108,11 +108,11 @@ parts:
         result = get_book_toc(tmp_path)
         assert result == [
                 tmp_path / '_build/html/intro.html',
-                tmp_path / '_build/html/_jb_part-1-name-of-part-1.html',
+                tmp_path / '_build/html/_jb_part-1-Name-of-Part-1.html',
                 tmp_path / '_build/html/part1/chapter1.html',
                 [tmp_path / '_build/html/part1/chapter2.html',
                  tmp_path / '_build/html/part1/section2-1.html'],
-                tmp_path / '_build/html/_jb_part-2-name-of-part-2.html',
+                tmp_path / '_build/html/_jb_part-2-Name-of-Part-2.html',
                 tmp_path / '_build/html/part2/chapter1.html',
                 [tmp_path / '_build/html/part2/chapter2.html',
                  tmp_path / '_build/html/part2/section2-1.html']
@@ -146,10 +146,10 @@ parts:
         assert result == [
                 tmp_path / '_build/html/intro.html',
                 tmp_path / '_build/html/path-to/00-Preface.html',
-                tmp_path / '_build/html/_jb_part-1-name-of-part-1.html',
+                tmp_path / '_build/html/_jb_part-1-Name-of-Part-1.html',
                 [tmp_path / '_build/html/part1/chapter2.html',
                  tmp_path / '_build/html/part1/section2-1.html'],
-                tmp_path / '_build/html/_jb_part-2-name-of-part-2.html',
+                tmp_path / '_build/html/_jb_part-2-Name-of-Part-2.html',
                 tmp_path / '_build/html/part2/chapter1.html',
                 [tmp_path / '_build/html/part2/chapter2.html',
                  tmp_path / '_build/html/part2/section2-1.html']
@@ -182,10 +182,10 @@ parts:
                 tmp_path / '_build/html/intro.html',
                 tmp_path / '_build/html/path-to/preface.html',
                 tmp_path / '_build/html/path-to/second-preface.html',
-                tmp_path / '_build/html/_jb_part-1-name-of-part-1.html',
+                tmp_path / '_build/html/_jb_part-1-Name-of-Part-1.html',
                 [tmp_path / '_build/html/part1/chapter2.html',
                  tmp_path / '_build/html/part1/chapter-section.html'],
-                tmp_path / '_build/html/_jb_part-2-name-of-part-2.html',
+                tmp_path / '_build/html/_jb_part-2-Name-of-Part-2.html',
                 tmp_path / '_build/html/part2/chapter1.html',
                 [tmp_path / '_build/html/part2/chapter2.html',
                  tmp_path / '_build/html/part2/section2-1.html']
@@ -213,11 +213,11 @@ parts:
                 tmp_path / '_build/html/intro.html',
                 tmp_path / '_build/html/path-to/preface.html',
                 tmp_path / '_build/html/path-to/second-preface.html',
-                tmp_path / '_build/html/_jb_part-1-name-of-part-1.html',
+                tmp_path / '_build/html/_jb_part-1-Name-of-Part-1.html',
                 [tmp_path / '_build/html/part1/chapter2.html',
                  tmp_path / '_build/html/part1/chapter-section.html',
                  tmp_path / '_build/html/part1/preface-1.html'],
-                tmp_path / '_build/html/_jb_part-2-name-of-part-2.html',
+                tmp_path / '_build/html/_jb_part-2-Name-of-Part-2.html',
                 tmp_path / '_build/html/example.html'
                ]
 


### PR DESCRIPTION
This had previously been added as a helper for authors, but it is confusing for the PEs (i.e., why would and in the TOC become And in the PDF), so we'll remove it.

Also, sneaking a CODEOWNERS into this repo.