### PR TITLE
Add ability to preserve Jupyter's code highlighting classes

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -19,3 +19,16 @@ def fresh_book_html(tmp_path_factory):
         return Path("tests/example_book/_build/html")
     else:
         return test_env / "_build/html"
+
+
+@pytest.fixture()
+def tmp_book_path(tmp_path):
+    """
+    Provides a copy of the example_book html jupyter book build
+    for use in tests.
+    """
+    test_env = tmp_path / 'tmp'
+    test_env.mkdir()
+    shutil.copytree('tests/example_book/_build/html',
+                    test_env, dirs_exist_ok=True)
+    return test_env

--- a/jupyter_book_to_htmlbook/file_processing.py
+++ b/jupyter_book_to_htmlbook/file_processing.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from pathlib import Path
-from typing import Union
+from typing import Union, Optional
 from bs4 import BeautifulSoup  # type: ignore
 from .admonition_processing import process_admonitions
 from .figure_processing import process_figures, process_informal_figs
@@ -222,7 +222,8 @@ def process_chapter(toc_element,
                     source_dir,
                     build_dir=Path('.'),
                     book_ids: list = [],
-                    skip_cell_numbering: bool = False):
+                    skip_cell_numbering: Optional[bool] = False,
+                    keep_highlighting: Optional[bool] = False):
     """
     Takes a list of chapter files and chapter lists and then writes the chapter
     to the root directory in which the script is run. Note that this assumes
@@ -251,7 +252,8 @@ def process_chapter(toc_element,
     chapter = process_math(chapter)
     # note: best to run examples before code processing
     chapter = process_code_examples(chapter)
-    chapter = process_code(chapter, skip_cell_numbering)
+    if not keep_highlighting:
+        chapter = process_code(chapter, skip_cell_numbering)
     chapter = process_inline_code(chapter)
     chapter = move_span_ids_to_sections(chapter)
     chapter = process_sidebars(chapter)

--- a/jupyter_book_to_htmlbook/main.py
+++ b/jupyter_book_to_htmlbook/main.py
@@ -43,6 +43,11 @@ def jupter_book_to_htmlbook(
             False,
             "--include-root",
             help="Include the 'root' file of the jupyter-book project"),
+        keep_highlighting: Optional[bool] = typer.Option(
+            False,
+            "--keep-highlighting",
+            help="Preserve any code highlighting provided by Jupyter Book",
+            ),
         version: Optional[bool] = typer.Option(
             None,
             "--version",
@@ -132,7 +137,8 @@ def jupter_book_to_htmlbook(
                                                 source_dir,
                                                 output_dir,
                                                 book_ids,
-                                                skip_cell_numbering)
+                                                skip_cell_numbering,
+                                                keep_highlighting)
             processed_files.append(f'{target}/{file}')
             book_ids.extend(chapter_ids)
 


### PR DESCRIPTION
This was an author request, and also might help us get around certain edge cases where authors' blocks aren't getting `data-typed` appropriately. We can feel pretty good about this, since Jupyter Book uses Pygments, the same code highlighter we do.

Also, a minor refactor of some copying files lines over to a `conftest.py` fixture.