### PR TITLE
Convert <span>s to <code>s inside <pre> blocks when keeping highlighting

### DIFF
--- a/jupyter_book_to_htmlbook/code_processing.py
+++ b/jupyter_book_to_htmlbook/code_processing.py
@@ -228,3 +228,21 @@ def example_get_name_and_title_r(pre_block):
             "Missing first two line comments for uuid and title." +
             f"Unable to apply example formatting: {error}.")
         return None, None
+
+
+def pre_spans_to_code_tags(chapter):
+    """
+    If we are preserving highlighting provided by Jupyter Book but want those
+    styles to show up correctly in Atlas, we need to turn the <span> tags
+    inside the Jupyter <pre> tags into <code> tags
+    """
+    highlight_divs = chapter.find_all(class_="highlight")
+
+    for div in highlight_divs:
+        pre_tag = div.pre
+        if pre_tag:
+            spans = pre_tag.find_all("span")
+            for span in spans:
+                span.name = "code"
+
+    return chapter

--- a/jupyter_book_to_htmlbook/file_processing.py
+++ b/jupyter_book_to_htmlbook/file_processing.py
@@ -17,7 +17,8 @@ from .reference_processing import (
 from .code_processing import (
         process_code,
         process_code_examples,
-        process_inline_code
+        process_inline_code,
+        pre_spans_to_code_tags
     )
 from .text_processing import (
         clean_chapter,
@@ -254,6 +255,8 @@ def process_chapter(toc_element,
     chapter = process_code_examples(chapter)
     if not keep_highlighting:
         chapter = process_code(chapter, skip_cell_numbering)
+    else:
+        chapter = pre_spans_to_code_tags(chapter)
     chapter = process_inline_code(chapter)
     chapter = move_span_ids_to_sections(chapter)
     chapter = process_sidebars(chapter)

--- a/tests/test_code_processing.py
+++ b/tests/test_code_processing.py
@@ -4,6 +4,7 @@ import re
 import shutil
 from bs4 import BeautifulSoup  # type: ignore
 from jupyter_book_to_htmlbook.code_processing import (
+        pre_spans_to_code_tags,
         process_code,
         process_inline_code,
         number_codeblock,
@@ -583,3 +584,21 @@ class TestInlineCode:
         expected = str(code_example_data_type)
         result = process_inline_code(code_example_data_type)
         assert str(result) == expected
+
+
+class TestKeepHighlighting:
+    """
+    Tests around preserving highlighting provided by Jupyter Book, but doing
+    enough to ensure they appear correctly inside Atlas
+    """
+
+    def test_pre_spans_to_code_tags(self):
+        """
+        Smoke test that we're correctly converting <span>s into <code>s inside
+        pre tags with highlighting
+        """
+        chapter = BeautifulSoup("""<div class="highlight"><pre>
+<span class="preserved">some code</span></pre></div>
+""", "html.parser")
+        result = pre_spans_to_code_tags(chapter)
+        assert result.find("pre").find("code")  # type: ignore

--- a/tests/test_file_processing.py
+++ b/tests/test_file_processing.py
@@ -351,6 +351,9 @@ id="this-is-another-subheading">
         """
         We want to be able to optionally pass Jupyter's highlighting through,
         e.g., in cases where we're not explicitly providing language support
+
+        In this case, the <span> tags inside the <pre> block need to be
+        converted into <code> tags so Atlas's css rules pick them up
         """
         test_out = tmp_book_path / "output"
         test_out.mkdir()
@@ -363,4 +366,5 @@ id="this-is-another-subheading">
 
         assert text.find('data-type="programlisting"') == -1
         assert text.find('data-code-language="') == -1
-        assert text.find('<span class="nb"') > 0
+        # spans should be converted to code tags for highlighting in Atlas
+        assert text.find('<code class="nb"') > 0


### PR DESCRIPTION
There is a discrepancy between what Jupyter Book spits out and what Atlas expects in terms of the target tags for code highlighting; out customization of Pygments provides <code> tags inside any <pre> tag with the appropriate data-type and data-code-language attributes, but Jupyter book instead gives <span> tags. Without weighing in on which is more semantic, this quick PR is to ensure that if an author chooses the `--keep-highlighting` option, the highlighting will actually make its way through to the web pdf and epub.