### PR TITLE
Allow styles on SVG elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ Options:
 
 ## Release Notes
 
+### 1.1.2
+
+Bug fix:
+- Allow "style" attributes to remain inside SVGs
+
 ### 1.1.1
 
 Bug fix:

--- a/jupyter_book_to_htmlbook/text_processing.py
+++ b/jupyter_book_to_htmlbook/text_processing.py
@@ -18,7 +18,18 @@ def clean_chapter(chapter, rm_numbering=True):
 
     for attr in remove_attrs:
         for tag in chapter.find_all(attrs={attr: True}):
-            del tag[attr]
+            # we need to allow styles on svg elements
+            in_svg = False
+            if attr == "style":
+
+                if tag.name == "svg":
+                    in_svg = True
+
+                for parent in tag.parents:
+                    if parent.name == "svg":
+                        in_svg = True
+            if not in_svg:
+                del tag[attr]
 
     # (optionally) remove numbering
     if rm_numbering:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jupyter-book-to-htmlbook"
-version = "1.1.1"
+version = "1.1.2"
 description = "A script to convert jupyter book html files to htmlbook for consumption in Atlas"
 authors = ["delfanbaum"]
 

--- a/tests/test_text_processing.py
+++ b/tests/test_text_processing.py
@@ -206,3 +206,25 @@ def test_hidden_output_is_removed():
     clean_chapter(chapter_text, False)
     assert not chapter_text.find("details")
     assert not chapter_text.find("div", class_="output")
+
+
+def test_svg_retains_attrs():
+    """
+    This is to get around styles applied to SVGs, which seems like
+    standard practice, for better or worse.
+    """
+    svg_ch = BeautifulSoup("""
+<div class="cell_output docutils container">
+<div class="output text_html">
+<svg width="250" height="150" style="color:blue">
+<rect width="100%" height="100%" fill="white"/>
+<line x1="125" y1="75" x2="225.0" y2="75.0" stroke-linecap="round" style="stroke:#663399;stroke-width:2"/>
+<g visibility="visible" transform="rotate(-90,225.0,75.0) translate(225.0, 75.0)">
+<circle stroke="gray" stroke-width="2" fill="transparent" r="5.5" cx="0" cy="0"/>
+<polygon points="0,12 2,9 -2,9" style="fill:gray;stroke:gray;stroke-width:2"/>
+</g>
+</svg>
+</div></div>""", "html.parser")
+    clean_chapter(svg_ch, False)
+    assert "stroke" in svg_ch.find("line").get('style')  # type:ignore
+    assert "blue" in svg_ch.find("svg").get('style')  # type:ignore


### PR DESCRIPTION
This appears to have been the issue in a previous book; embedded styles are often used in SVGs, so we need to allow those through processing.