### PR TITLE
Adjust logic for selecting top-level sections

### DIFF
--- a/jupyter_book_to_htmlbook/file_processing.py
+++ b/jupyter_book_to_htmlbook/file_processing.py
@@ -141,10 +141,15 @@ def get_top_level_sections(soup):
     all but bibliography sections
     """
     section_wrappers = soup.find_all("article", attrs={"role": "main"})
+    top_level_sections = []
 
     # test case for partial files, not expected in production
     if len(section_wrappers) == 0:
         sections = soup.find_all('section')
+
+        for section in sections:
+            if section.find_parent('section') is None:
+                top_level_sections.append(section)
     elif len(section_wrappers) != 1:
         article = soup.find('article', attrs={"role": "main"})
         try:
@@ -156,16 +161,15 @@ def get_top_level_sections(soup):
         return None, None
     else:
         main = section_wrappers[0]
-        sections = []
 
         for element in main.children:
             if (
                     element.name == "section" and
                     element.get('id') != "bibliography"
                ):
-                sections.append(element)
+                top_level_sections.append(element)
 
-    return sections
+    return top_level_sections
 
 
 def get_main_section(soup):

--- a/tests/example_book/_build/html/no_wrapper.html
+++ b/tests/example_book/_build/html/no_wrapper.html
@@ -1,0 +1,438 @@
+
+
+<!DOCTYPE html>
+
+
+<html lang="en" >
+
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="generator" content="Docutils 0.17.1: http://docutils.sourceforge.net/" />
+
+    <title>Chapter Title &#8212; My Jupyter Book</title>
+  
+  
+  
+  <script data-cfasync="false">
+    document.documentElement.dataset.mode = localStorage.getItem("mode") || "";
+    document.documentElement.dataset.theme = localStorage.getItem("theme") || "light";
+  </script>
+  
+  <!-- Loaded before other Sphinx assets -->
+  <link href="_static/styles/theme.css?digest=e353d410970836974a52" rel="stylesheet" />
+<link href="_static/styles/bootstrap.css?digest=e353d410970836974a52" rel="stylesheet" />
+<link href="_static/styles/pydata-sphinx-theme.css?digest=e353d410970836974a52" rel="stylesheet" />
+
+  
+  <link href="_static/vendor/fontawesome/6.1.2/css/all.min.css?digest=e353d410970836974a52" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="_static/vendor/fontawesome/6.1.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="_static/vendor/fontawesome/6.1.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="_static/vendor/fontawesome/6.1.2/webfonts/fa-regular-400.woff2" />
+
+    <link rel="stylesheet" type="text/css" href="_static/pygments.css" />
+    <link rel="stylesheet" href="_static/styles/sphinx-book-theme.css?digest=14f4ca6b54d191a8c7657f6c759bf11a5fb86285" type="text/css" />
+    <link rel="stylesheet" type="text/css" href="_static/togglebutton.css" />
+    <link rel="stylesheet" type="text/css" href="_static/copybutton.css" />
+    <link rel="stylesheet" type="text/css" href="_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="_static/sphinx-thebe.css" />
+    <link rel="stylesheet" type="text/css" href="_static/design-style.4045f2051d55cab465a707391d5b2007.min.css" />
+  
+  <!-- Pre-loaded scripts that we'll load fully later -->
+  <link rel="preload" as="script" href="_static/scripts/bootstrap.js?digest=e353d410970836974a52" />
+<link rel="preload" as="script" href="_static/scripts/pydata-sphinx-theme.js?digest=e353d410970836974a52" />
+
+    <script data-url_root="./" id="documentation_options" src="_static/documentation_options.js"></script>
+    <script src="_static/jquery.js"></script>
+    <script src="_static/underscore.js"></script>
+    <script src="_static/_sphinx_javascript_frameworks_compat.js"></script>
+    <script src="_static/doctools.js"></script>
+    <script src="_static/clipboard.min.js"></script>
+    <script src="_static/copybutton.js"></script>
+    <script src="_static/scripts/sphinx-book-theme.js?digest=5a5c038af52cf7bc1a1ec88eea08e6366ee68824"></script>
+    <script>let toggleHintShow = 'Click to show';</script>
+    <script>let toggleHintHide = 'Click to hide';</script>
+    <script>let toggleOpenOnPrint = 'true';</script>
+    <script src="_static/togglebutton.js"></script>
+    <script>var togglebuttonSelector = '.toggle, .admonition.dropdown';</script>
+    <script src="_static/design-tabs.js"></script>
+    <script>const THEBE_JS_URL = "https://unpkg.com/thebe@0.8.2/lib/index.js"
+const thebe_selector = ".thebe,.cell"
+const thebe_selector_input = "pre"
+const thebe_selector_output = ".output, .cell_output"
+</script>
+    <script async="async" src="_static/sphinx-thebe.js"></script>
+    <script>const THEBE_JS_URL = "https://unpkg.com/thebe@0.8.2/lib/index.js"
+const thebe_selector = ".thebe,.cell"
+const thebe_selector_input = "pre"
+const thebe_selector_output = ".output, .cell_output"
+</script>
+    <script async="async" src="_static/sphinx-thebe.js"></script>
+    <script>DOCUMENTATION_OPTIONS.pagename = 'no_wrapper';</script>
+    <link rel="index" title="Index" href="genindex.html" />
+    <link rel="search" title="Search" href="search.html" />
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <meta name="docsearch:language" content="en"/>
+  </head>
+  
+  
+  <body data-bs-spy="scroll" data-bs-target=".bd-toc-nav" data-offset="180" data-bs-root-margin="0px 0px -60%" data-default-mode="">
+
+  
+  
+  <a class="skip-link" href="#main-content">Skip to main content</a>
+  
+  <input type="checkbox"
+          class="sidebar-toggle"
+          name="__primary"
+          id="__primary"/>
+  <label class="overlay overlay-primary" for="__primary"></label>
+  
+  <input type="checkbox"
+          class="sidebar-toggle"
+          name="__secondary"
+          id="__secondary"/>
+  <label class="overlay overlay-secondary" for="__secondary"></label>
+  
+  <div class="search-button__wrapper">
+    <div class="search-button__overlay"></div>
+    <div class="search-button__search-container">
+<form class="bd-search d-flex align-items-center"
+      action="search.html"
+      method="get">
+  <i class="fa-solid fa-magnifying-glass"></i>
+  <input type="search"
+         class="form-control"
+         name="q"
+         id="search-input"
+         placeholder="Search this book..."
+         aria-label="Search this book..."
+         autocomplete="off"
+         autocorrect="off"
+         autocapitalize="off"
+         spellcheck="false"/>
+  <span class="search-button__kbd-shortcut"><kbd class="kbd-shortcut__modifier">Ctrl</kbd>+<kbd>K</kbd></span>
+</form></div>
+  </div>
+  
+    <nav class="bd-header navbar navbar-expand-lg bd-navbar">
+    </nav>
+  
+  <div class="bd-container">
+    <div class="bd-container__inner bd-page-width">
+      
+      <div class="bd-sidebar-primary bd-sidebar">
+        
+
+  
+  <div class="sidebar-header-items sidebar-primary__section">
+    
+    
+    
+    
+  </div>
+  
+    <div class="sidebar-primary-items__start sidebar-primary__section">
+        <div class="sidebar-primary-item">
+  
+
+<a class="navbar-brand logo" href="#">
+  
+  
+  
+  
+  
+    <p class="title logo__title">My Jupyter Book</p>
+  
+</a></div>
+        <div class="sidebar-primary-item"><nav class="bd-links" id="bd-docs-nav" aria-label="Main">
+    <div class="bd-toc-item navbar-nav active">
+        
+        <ul class="nav bd-sidenav bd-sidenav__home-link">
+            <li class="toctree-l1 current active">
+                <a class="reference internal" href="#">
+                    Chapter Title
+                </a>
+            </li>
+        </ul>
+        
+    </div>
+</nav></div>
+    </div>
+  
+  
+  <div class="sidebar-primary-items__end sidebar-primary__section">
+  </div>
+  
+  <div id="rtd-footer-container"></div>
+
+
+      </div>
+      
+      <main id="main-content" class="bd-main">
+        
+        
+
+<div class="sbt-scroll-pixel-helper"></div>
+
+          <div class="bd-content">
+            <div class="bd-article-container">
+              
+              <div class="bd-header-article">
+<div class="header-article-items header-article__inner">
+  
+    <div class="header-article-items__start">
+      
+        <div class="header-article-item"><label class="sidebar-toggle primary-toggle btn btn-sm" for="__primary" title="Toggle primary sidebar" data-bs-placement="bottom" data-bs-toggle="tooltip">
+  <span class="fa-solid fa-bars"></span>
+</label></div>
+      
+    </div>
+  
+  
+    <div class="header-article-items__end">
+      
+        <div class="header-article-item">
+
+<div class="article-header-buttons">
+
+
+
+
+
+<div class="dropdown dropdown-download-buttons">
+  <button class="btn dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Download this page">
+    <i class="fas fa-download"></i>
+  </button>
+  <ul class="dropdown-menu">
+      
+      
+      
+      <li><a href="_sources/no_wrapper.ipynb" target="_blank"
+   class="btn btn-sm btn-download-source-button dropdown-item"
+   title="Download source file"
+   data-bs-placement="left" data-bs-toggle="tooltip"
+>
+  
+
+<span class="btn__icon-container">
+  <i class="fas fa-file"></i>
+  </span>
+<span class="btn__text-container">.ipynb</span>
+</a>
+</li>
+      
+      
+      
+      
+      <li>
+<button onclick="window.print()"
+  class="btn btn-sm btn-download-pdf-button dropdown-item"
+  title="Print to PDF"
+  data-bs-placement="left" data-bs-toggle="tooltip"
+>
+  
+
+<span class="btn__icon-container">
+  <i class="fas fa-file-pdf"></i>
+  </span>
+<span class="btn__text-container">.pdf</span>
+</button>
+</li>
+      
+  </ul>
+</div>
+
+
+
+
+<button onclick="toggleFullScreen()"
+  class="btn btn-sm btn-fullscreen-button"
+  title="Fullscreen mode"
+  data-bs-placement="bottom" data-bs-toggle="tooltip"
+>
+  
+
+<span class="btn__icon-container">
+  <i class="fas fa-expand"></i>
+  </span>
+
+</button>
+
+
+<script>
+document.write(`
+  <button class="theme-switch-button btn btn-sm btn-outline-primary navbar-btn rounded-circle" title="light/dark" aria-label="light/dark" data-bs-placement="bottom" data-bs-toggle="tooltip">
+    <span class="theme-switch" data-mode="light"><i class="fa-solid fa-sun"></i></span>
+    <span class="theme-switch" data-mode="dark"><i class="fa-solid fa-moon"></i></span>
+    <span class="theme-switch" data-mode="auto"><i class="fa-solid fa-circle-half-stroke"></i></span>
+  </button>
+`);
+</script>
+
+<script>
+document.write(`
+  <button class="btn btn-sm navbar-btn search-button search-button__button" title="Search" aria-label="Search" data-bs-placement="bottom" data-bs-toggle="tooltip">
+    <i class="fa-solid fa-magnifying-glass"></i>
+  </button>
+`);
+</script>
+<label class="sidebar-toggle secondary-toggle btn btn-sm" for="__secondary"title="Toggle secondary sidebar" data-bs-placement="bottom" data-bs-toggle="tooltip">
+    <span class="fa-solid fa-list"></span>
+</label>
+</div></div>
+      
+    </div>
+  
+</div>
+</div>
+              
+              
+
+<div id="jb-print-docs-body" class="onlyprint">
+    <h1>Chapter Title</h1>
+    <!-- Table of contents -->
+    <div id="print-main-content">
+        <div id="jb-print-toc">
+            
+            <div>
+                <h2> Contents </h2>
+            </div>
+            <nav aria-label="Page">
+                <ul class="visible nav section-nav flex-column">
+<li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#first-first-level-subsection-heading">First First-Level Subsection Heading</a></li>
+<li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#section-first-level-subsection-heading">Section First-Level Subsection Heading</a></li>
+<li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#third-first-level-subsection-heading">Third First-Level Subsection Heading</a></li>
+</ul>
+            </nav>
+        </div>
+    </div>
+</div>
+
+              
+                
+<div id="searchbox"></div>
+                <article class="bd-article"><!-- article wrapper is missing role="main" -->
+                  
+  <section class="tex2jax_ignore mathjax_ignore" id="chapter-title">
+<span id="chapter-1"></span><h1>Chapter Title<a class="headerlink" href="#chapter-title" title="Permalink to this heading">#</a></h1>
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin vehicula mauris nulla, id finibus orci accumsan placerat. Mauris rhoncus ex in ipsum pellentesque, sed blandit arcu scelerisque. Aenean ut malesuada ligula. Mauris porttitor finibus nunc in dignissim. Phasellus sed diam gravida, aliquet nisi quis, placerat sapien. In augue lacus, egestas accumsan vulputate non, gravida at ex. Vivamus malesuada lectus nec blandit ultricies. Duis feugiat tortor vitae velit accumsan, eu imperdiet purus mattis. Fusce eu viverra arcu. Duis nec ex varius, tristique turpis ut, blandit sapien. Quisque non pellentesque nulla, vitae varius arcu. In maximus auctor pretium. Nunc elementum ac diam ut lobortis. Aliquam nec sapien eu ligula commodo aliquam. Integer in molestie libero, dignissim rhoncus lorem. Donec a laoreet magna.</p>
+<section id="first-first-level-subsection-heading">
+<span id="section-1"></span><h2>First First-Level Subsection Heading<a class="headerlink" href="#first-first-level-subsection-heading" title="Permalink to this heading">#</a></h2>
+<p>Sed nec vehicula nibh. Praesent vitae commodo lacus, sed vestibulum lacus. In egestas felis faucibus ultrices dapibus. Sed consectetur quam et leo tristique convallis. Nulla a diam libero. Vestibulum sit amet neque imperdiet, dictum urna sed, vehicula dolor. Integer tincidunt vulputate ex, at cursus tortor molestie sed. Maecenas at posuere justo. Nunc massa erat, rutrum id volutpat gravida, rhoncus in quam. Phasellus ex purus, consectetur nec dui ut, ultrices porta tortor.</p>
+</section>
+<section id="section-first-level-subsection-heading">
+<span id="section-2"></span><h2>Section First-Level Subsection Heading<a class="headerlink" href="#section-first-level-subsection-heading" title="Permalink to this heading">#</a></h2>
+<p>Since 1973 the U.S. Centers for Disease Control and Prevention (CDC) have conducted the National Survey of Family Growth (NSFG), which is intended to gather “information on family life, marriage and divorce, pregnancy, infertility, use of contraception, and men’s and women’s health. The survey results are used…to plan health services and health education programs, and to do statistical studies of families, fertility, and health.”</p>
+</section>
+<section id="third-first-level-subsection-heading">
+<span id="section-3"></span><h2>Third First-Level Subsection Heading<a class="headerlink" href="#third-first-level-subsection-heading" title="Permalink to this heading">#</a></h2>
+<p>In malesuada sagittis libero ut bibendum. Sed dolor lacus, placerat eu ultricies nec, sollicitudin imperdiet sem. Vestibulum condimentum est a lacinia suscipit. Fusce vitae lacus et magna sollicitudin pulvinar. Morbi erat ipsum, vehicula sed orci et, rutrum hendrerit justo. Phasellus porttitor elementum mattis. Ut et commodo ligula.</p>
+</section>
+</section>
+
+    <script type="text/x-thebe-config">
+    {
+        requestKernel: true,
+        binderOptions: {
+            repo: "binder-examples/jupyter-stacks-datascience",
+            ref: "master",
+        },
+        codeMirrorConfig: {
+            theme: "abcdef",
+            mode: "python"
+        },
+        kernelOptions: {
+            name: "python3",
+            path: "./."
+        },
+        predefinedOutput: true
+    }
+    </script>
+    <script>kernelName = 'python3'</script>
+
+                </article>
+              
+
+              
+              
+                <footer class="bd-footer-article">
+                  
+<div class="footer-article-items footer-article__inner">
+  
+    <div class="footer-article-item"><!-- Previous / next buttons -->
+<div class="prev-next-area">
+</div></div>
+  
+</div>
+
+                </footer>
+              
+            </div>
+            
+            
+              
+                <div class="bd-sidebar-secondary bd-toc"><div class="sidebar-secondary-items sidebar-secondary__inner">
+
+  <div class="sidebar-secondary-item">
+  <div class="page-toc tocsection onthispage">
+    <i class="fa-solid fa-list"></i> Contents
+  </div>
+  <nav class="bd-toc-nav page-toc">
+    <ul class="visible nav section-nav flex-column">
+<li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#first-first-level-subsection-heading">First First-Level Subsection Heading</a></li>
+<li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#section-first-level-subsection-heading">Section First-Level Subsection Heading</a></li>
+<li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#third-first-level-subsection-heading">Third First-Level Subsection Heading</a></li>
+</ul>
+  </nav></div>
+
+</div></div>
+              
+            
+          </div>
+          <footer class="bd-footer-content">
+            
+<div class="bd-footer-content__inner container">
+  
+  <div class="footer-item">
+    
+<p class="component-author">
+By The Jupyter Book community
+</p>
+
+  </div>
+  
+  <div class="footer-item">
+    
+  <p class="copyright">
+    
+      © Copyright 2022.
+      <br/>
+    
+  </p>
+
+  </div>
+  
+  <div class="footer-item">
+    
+  </div>
+  
+  <div class="footer-item">
+    
+  </div>
+  
+</div>
+          </footer>
+        
+
+      </main>
+    </div>
+  </div>
+  
+  <!-- Scripts loaded after <body> so the DOM is not blocked -->
+  <script src="_static/scripts/bootstrap.js?digest=e353d410970836974a52"></script>
+<script src="_static/scripts/pydata-sphinx-theme.js?digest=e353d410970836974a52"></script>
+
+  <footer class="bd-footer">
+  </footer>
+  </body>
+</html>

--- a/tests/test_file_processing.py
+++ b/tests/test_file_processing.py
@@ -64,6 +64,28 @@ class TestChapterProcess:
         # check on return
         assert "ch01.html" in result
 
+    def test_process_chapter_with_no_main_wrapper(self, tmp_book_path):
+        """
+        ensure a chapter with no main wrapper but with a single
+        top-level section can be processed
+
+        observed edge cases:
+        article wrapper present but has no role attr with value of main
+        wrapper element is of type main rather than article
+        """
+        test_env = tmp_book_path
+        test_out = test_env / 'output'
+        test_out.mkdir()
+
+        process_chapter((test_env / 'no_wrapper.html'), test_env, test_out)
+
+        with open(test_out / 'no_wrapper.html') as f:
+            text = f.read()
+            assert 'section data-type="chapter" id="chapter-1"' in text
+            assert 'data-type="sect1" id="section-1"' in text
+            assert 'data-type="sect1" id="section-2"' in text
+            assert 'data-type="sect1" id="section-3"' in text
+
     def test_process_chapter_single_file_with_multiple_h1s(self,
                                                            tmp_book_path,
                                                            caplog,


### PR DESCRIPTION
Hey team, this PR follows on #71, which I posted after trying to convert a bunch of notebook files where the section/chapter wrapper didn't match the pattern used in get_top_level_sections.

With this adjustment, in instances where a wrapper isn't found, the function will try to grab a list of top-level sections (currently we list all sections, I think). If there's more than one top-level section, the existing warning is logged; otherwise, we can proceed with processing the single top-level section.

Hopefully, most of the the time the notebooks we're working with will follow the expected form, but I've seen this week two patterns (albeit in the same project) that were well formed overall but not as expected:

- article wrapper is present but has no role attribute
- wrapper with role of main has tag type of main rather than article
 
PR includes a test case with data matching the former of the two above patterns. Let me know if you have feedback or want me to make any changes. Thanks!
